### PR TITLE
詳細ページ作成/デフォルト位置変更

### DIFF
--- a/app/views/spots/map.html.erb
+++ b/app/views/spots/map.html.erb
@@ -18,9 +18,9 @@
         // 地図要素：HTMLの要素 id="map" を持つ div 要素を取得し、その中に地図を表示
         const mapElement = document.getElementById('map');
 
-        // 地図のオプション（デフォルト位置：東京）
+        // 地図のオプション（デフォルト位置：島根）
         const defaultMapOptions = {
-        center: { lat: 35.6803997, lng: 139.7690174 },
+        center: { lat: 35.472295, lng: 133.050499 }, // 島根県松江市の緯度経度
         zoom: 12
         };
 

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,1 +1,90 @@
 <% content_for(:title, @spot.name) %>
+
+<div class="w-5/6 mx-auto max-w-sm">
+    <div class="mt-8">
+        <div class="card">
+            <div class="m-4">
+                <%# Spot画像 %>
+                <% if @spot.photo_reference.present? %>
+                    <%= image_tag "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=#{@spot.photo_reference}&key=#{ENV["GOOGLE_MAPS_API_KEY"]}", class: "rounded-xl" %>
+                <% end %>
+                <%# Spot名 %>
+                <h1 class="font-bold text-xl mt-4">
+                    <%= @spot.name %>
+                </h1>
+                <%# カテゴリ名 %>
+                <p class="text-black mt-4 badge badge-primary">
+                    <%= @spot.category.name %>
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+
+<div class="w-5/6 mx-auto max-w-sm md:max-w-4xl">
+    <div class="mt-10 mb-28">
+        <div class="card shadow-xl">
+            <div class="m-4">
+                <%# Spot住所 %>
+                <div class="mb-2">
+                    <div class="flex justify-start">
+                        <div class="mr-2">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="red" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" /><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z" /></svg>
+                        </div>
+                        <div class="text-sm">
+                            <%= @spot.address %>
+                        </div>
+                    </div>
+                </div>
+
+                <%# Spot電話番号 %>
+                <div class="mb-2">
+                    <div class="flex justify-start">
+                        <div class="mr-2">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 0 0 2.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 0 1-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 0 0-1.091-.852H4.5A2.25 2.25 0 0 0 2.25 4.5v2.25Z" /></svg>
+                        </div>
+                        <div class="text-sm">
+                            <% if @spot.phone_number.present? %>
+                                <%= link_to @spot.phone_number, "tel:#{@spot.phone_number}", class: "link link-hover" %>
+                            <% else %>
+                                <p>データがありません</p>
+                            <% end %>
+                        </div>
+                    </div>
+                </div>
+
+                <%# Spot公式HP %>
+                <div class="mb-2">
+                    <div class="flex justify-start">
+                        <div class="mr-2">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418" /></svg>
+                        </div>
+                        <div class="text-sm">
+                            <% if @spot.web_site.present? %>
+                                <%= link_to "公式HPリンク", "#{@spot.web_site}", target: :_blank, rel: "noopener noreferrer", class: "link link-hover" %>
+                            <% else %>
+                                <p>データがありません</p>
+                            <% end %>
+                        </div>
+                    </div>
+                </div>
+
+                <%# Spot営業時間 %>
+                <div class="card">
+                    <div class="text-center text-sm">
+                        <div class="border border-base-300 p-4">
+                            <p class="font-bold mb-2">営業時間</p>
+                            <% if @spot.opening_hours.nil? %>
+                                <p>データがありません</p>
+                            <% else %>
+                                <p><%= simple_format(@spot.opening_hours) %></p>
+                            <% end %>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
■概要
・詳細ページ作成(画像、住所、電話番号、公式ＨＰ表示)
・デフォルト位置

■内容
・show.html.erbに画像、住所、電話番号、公式ＨＰが表示されるように記述
・デフォルト位置を東京から島根に変更