### PR TITLE
N+1問題対策

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -2,7 +2,7 @@ class SpotsController < ApplicationController
   skip_before_action :require_login
   
   def map
-    @spots = Spot.all
+    @spots = Spot.includes(:category).all
   end
 
   def index


### PR DESCRIPTION
■概要
・N+1問題対策

■内容
・ログを確認するとマップ表示を読み込む際にN+1問題が発生していたので、
Spotsコントローラーのmapメソッド内を修正した。