### PR TITLE
該当するデータが存在しない場合に適切なエラーメッセージを表示

### DIFF
--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -21,6 +21,12 @@ class SuggestionsController < ApplicationController
     # Spotデータから条件に合う候補を取得
     spots = Spot.where(category_id: category_id, prefecture_id: prefecture_id)
 
+    # 登録されているスポットが存在しない場合の処理
+    if spots.empty?
+      flash[:alert] = "条件に一致するおすすめスポットは見つかりませんでした。"
+      redirect_to suggestions_path and return
+    end
+
     # 取得したデータをAIで分析するためにテキスト化
     spot_names = spots.pluck(:name).join(', ')
     prompt_text = <<~TEXT


### PR DESCRIPTION
■概要
・Spotモデルから条件に一致するデータを取得する際、該当するデータが存在しない場合に適切なエラーメッセージを表示する処理を追加

■内容
・条件に一致するスポットがなかった場合、フラッシュメッセージを設定して、ユーザーに「条件に一致するおすすめスポットは見つかりませんでした。」というメッセージを表示
・該当するスポットがない場合は、再度 `/suggestions` ページへリダイレクト
