### PR TITLE
マイページの作成

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,13 @@
+class ProfilesController < ApplicationController
+  before_action :set_user, only: [:index]
+
+  def index
+    @bookmark_spots = @user.bookmark_spots
+  end
+
+  private
+
+  def set_user
+    @user = current_user
+  end
+end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -17,8 +17,6 @@ class SpotsController < ApplicationController
   end
 
   def bookmarks
-    if current_user
-      @bookmark_spots = current_user.bookmark_spots.includes(:user).order(created_at: :desc)
-    end
+    @bookmark_spots = current_user.bookmark_spots.includes(:user).order(created_at: :desc)
   end
 end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,2 @@
+module ProfilesHelper
+end

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,6 +1,29 @@
-<h1>マイページ</h1>
+<div class="min-h-screen flex flex-col items-center justify-start pt-16 px-4">
+  <!-- タイトル -->
+  <div class="text-xl sm:text-2xl font-bold mb-6">マイページ</div>
 
-<p>ユーザー名: <%= @user.name %></p>
-<p>メール: <%= @user.email %></p>
+  <div class="w-5/6 max-w-sm md:max-w-4xl">
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <!-- アイコンとタイトルを横並びにする -->
+      <div class="flex items-center mb-4">
+        <!-- アイコン -->
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 mr-4 text-blue-500" viewBox="0 0 448 512">
+          <path d="M304 128a80 80 0 1 0 -160 0 80 80 0 1 0 160 0zM96 128a128 128 0 1 1 256 0A128 128 0 1 1 96 128zM49.3 464l349.5 0c-8.9-63.3-63.3-112-129-112l-91.4 0c-65.7 0-120.1 48.7-129 112zM0 482.3C0 383.8 79.8 304 178.3 304l91.4 0C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7L29.7 512C13.3 512 0 498.7 0 482.3z"/>
+        </svg>
 
-<%= link_to "ブックマーク一覧", bookmarks_spots_path, class: "text-sm btm-nav-label" %>
+        <!-- タイトル -->
+        <h2 class="text-2xl font-semibold">ユーザー情報</h2>
+      </div>
+
+      <!-- ユーザー情報 -->
+      <div class="mb-4">
+        <p class="text-xl mb-2">ユーザー名: <strong><%= @user.name %></strong></p>
+        <p class="text-xl mb-4">メール: <strong><%= @user.email %></strong></p>
+      </div>
+
+      <div class="mt-4">
+        <%= link_to "ブックマーク一覧", bookmarks_spots_path, class: "text-blue-500 hover:underline" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,0 +1,6 @@
+<h1>マイページ</h1>
+
+<p>ユーザー名: <%= @user.name %></p>
+<p>メール: <%= @user.email %></p>
+
+<%= link_to "ブックマーク一覧", bookmarks_spots_path, class: "text-sm btm-nav-label" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -21,6 +21,6 @@
   </button>
   <button class="hover:bg-gray-300">
   <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 448 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M304 128a80 80 0 1 0 -160 0 80 80 0 1 0 160 0zM96 128a128 128 0 1 1 256 0A128 128 0 1 1 96 128zM49.3 464l349.5 0c-8.9-63.3-63.3-112-129-112l-91.4 0c-65.7 0-120.1 48.7-129 112zM0 482.3C0 383.8 79.8 304 178.3 304l91.4 0C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7L29.7 512C13.3 512 0 498.7 0 482.3z"/></svg>
-    <%= link_to "マイページ", bookmarks_spots_path, class: "text-sm btm-nav-label" %>
+    <%= link_to "マイページ", profiles_path, class: "text-sm btm-nav-label" %>
   </button>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
   #ユーザー登録のルーティング
   resources :users, only: %i[new create]
 
+  # プロフィール関連のルート
+  resources :profiles, only: [:index]
+
   # OAuth認証のコールバックを処理するルーティング（認証プロバイダからのリダイレクトを受け取る）
   post "oauth/callback" => "oauths#callback"
   get "oauth/callback" => "oauths#callback" 

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
■概要
・マイページ表示のためのコントローラーとビューの実装

■内容
・ProfilesControllerを作成
 - index アクションでユーザーのブックマークしたスポット一覧を取得する処理を追加
 - before_action :set_userを定義し、@userにcurrent_user をセット
 
・app/views/profiles/index.html.erbでユーザー情報を表示
・プロフィールページを表示するためのルーティングを追加
・フッターにマイページへのリンクを追加

close #18 