### PR TITLE
SpotモデルとReviewモデルのテストコード追加

### DIFF
--- a/spec/models/reviews_spec.rb
+++ b/spec/models/reviews_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Review, type: :model do
+  describe '.ransackable_attributes' do
+    it '検索可能な関連の配列を返すこと' do
+      expected_attributes = %w[body]
+      expect(Review.ransackable_attributes).to eq(expected_attributes)
+    end
+  end
+end

--- a/spec/models/spots_spec.rb
+++ b/spec/models/spots_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Spot, type: :model do 
+
+  describe '.ransackable_attributes' do
+    it '検索可能な属性の配列を返すこと' do
+      expected_attributes = %w[
+        address category_id created_at id id_value latitude longitude name opening_hours phone_number
+        photo_reference place_id postal_code rating updated_at web_site
+      ]
+      expect(Spot.ransackable_attributes).to eq(expected_attributes)
+    end
+  end
+
+  describe '.ransackable_associations' do
+    it '検索可能な関連の配列を返すこと' do
+      expected_associations = %w[category]
+      expect(Spot.ransackable_associations).to eq(expected_associations)
+    end
+  end
+end


### PR DESCRIPTION
■概要
- SpotモデルとReviewモデルの ransackable属性・関連のテストを追加

■内容
- Reviewモデルのテストコード追加
    -  Review.ransackable_attributesのテストを追加
   
- Spotモデルのテストコード追加
    - Spot.ransackable_attributesのテストを追加
    - Spot.ransackable_associationsのテストを追加
   
- rspecが実行できることを確認

   - 以下の3つのテストを実装し、全て成功
   1. Spot.ransackable_attributesが正しい属性を返すこと
   2. Spot.ransackable_associationsが正しい関連を返すこと
   3. Review.ransackable_attributesが正しい属性を返すこと

##実行結果

![44f21bb5c49d95da6935e7aa543d9410](https://github.com/user-attachments/assets/da47be9c-7609-4734-b719-c9b62d6fa120)

![34e596f67ee3b816210619176b2b9424](https://github.com/user-attachments/assets/d1966c4e-b608-4264-8aea-c440ee735185)




