### PR TITLE
口コミ検索機能の拡充

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@
 
 | カテゴリ       | 技術スタック                                                              | 
 | -------------- | ------------------------------------------------------------------------- | 
-| フロントエンド | Rails 7.1.3.4 (Hotwire/Turbo/Stimulus), JavaScript, Tailwind CSS, daisyUI | 
-| バックエンド   | Rails 7.1.3.4 (Ruby 3.2.3)                                                | 
+| フロントエンド | 7.2.2.1(Hotwire/Turbo/Stimulus), JavaScript, Tailwind CSS, daisyUI | 
+| バックエンド   | Rails 7.2.2.1(Ruby3.3.6)                                                | 
 | データベース   | PostgreSQL                                                                | 
-| インフラ       | Render.com S3                                                     | 
+| インフラ       | Render.com                                                      | 
 | 開発環境       | Docker                                                                    | 
 | 認証           | Sorcery, Googleログイン                                                   | 
 | API            | Google Maps API, Open AI API, Google Custom Search API                                         | 

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -6,10 +6,10 @@ class Review < ApplicationRecord
 
   # ransackの検索可能な属性を定義
   def self.ransackable_attributes(auth_object = nil)
-    ["body"]
+    ["spot_id", "body", "created_at", "updated_at"]
   end
   # 検索可能な関連付けを追加
   def self.ransackable_associations(auth_object = nil)
-    [] 
+    ["spot"] 
   end
 end

--- a/app/views/reviews/_search_form.html.erb
+++ b/app/views/reviews/_search_form.html.erb
@@ -2,7 +2,7 @@
   <div class="w-5/6 mx-auto max-w-sm md:max-w-4xl m-3">
     <div class="flex justify-center">
       <div class="join w-full">
-        <%= f.search_field :body_cont, class: 'input input-bordered join-item text-sm w-full', placeholder: '口コミを探す' %>
+        <%= f.search_field :body_or_spot_name_or_spot_address_cont, class: 'input input-bordered join-item text-sm w-full', placeholder: '口コミを探す' %>
         <%= f.submit '検索', class: 'btn join-item' %>
       </div>
     </div>


### PR DESCRIPTION
■内容
- 口コミ検索機能の拡充
- READMEの修正

■概要
- Review.ransackable_attributes に spot_id, created_at, updated_at を追加
- Review.ransackable_associations に spot を追加
- 検索フォームで 口コミ本文・スポット名・住所 を横断的に検索可能にした
- READMEの使用技術（技術スタック）を修正
