### PR TITLE
一覧表示画面にレーティング追加/AI診断機能プロンプト調整

### DIFF
--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -28,7 +28,7 @@ class SuggestionsController < ApplicationController
     end
 
     # 取得したデータをAIで分析するためにテキスト化
-    spot_names = spots.pluck(:name).join(', ')
+    spot_names = spots.pluck(:name).shuffle.join(', ')
     category_name = Category.find(category_id).name
     prefecture_name = Prefecture.find(prefecture_id).name
 

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -10,10 +10,16 @@
 
       <%# Spotカテゴリ名・レーティング %>
       <div class="mb-4">
-          <%# カテゴリ名 %>
-          <p class="text-white font-bold badge badge-primary mt-4">
-            <%= spot.category.name %>
+        <%# カテゴリ名 %>
+        <p class="text-white font-bold badge badge-primary mt-4">
+          <%= spot.category.name %>
+        </p>
+        <%# レーティング %>
+        <% if spot.rating.present? %>
+          <p class="text-sm text-white font-bold badge badge-primary mt-4">
+            ⭐️ <%= spot.rating %>
           </p>
+        <% end %>
       </div>
 
       <%# Spot住所 %>


### PR DESCRIPTION
■内容
- 一覧表示画面にレーティング追加
- AI診断機能のスポット名リストの順序をランダム化

■概要
- spot.rating がある場合のみ、⭐️でレーティングを表示するよう _spot.html.erb を修正
- スポット名の並び順をランダムにすることで、選定結果の偏りを軽減