### PR TITLE
オートコンプリート機能の実装

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -19,4 +19,11 @@ class SpotsController < ApplicationController
   def bookmarks
     @bookmark_spots = current_user.bookmark_spots.includes(:user).order(created_at: :desc)
   end
+
+  def auto_search
+    @spots = Spot.where("name ILIKE ?", "%#{params[:q]}%")
+    respond_to do |format|
+      format.js
+    end
+  end
 end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,6 +1,8 @@
 import { Application } from "@hotwired/stimulus"
+import { Autocomplete } from 'stimulus-autocomplete'
 
 const application = Application.start()
+application.register('autocomplete', Autocomplete)
 
 // Configure Stimulus development experience
 application.debug = false

--- a/app/views/spots/_search_form.html.erb
+++ b/app/views/spots/_search_form.html.erb
@@ -2,7 +2,11 @@
   <div class="w-5/6 mx-auto max-w-sm md:max-w-4xl m-3">
     <div class="flex justify-center">
       <div class="join w-full">
-        <%= f.search_field :name_or_address_cont, class: 'input input-bordered join-item text-sm w-full', placeholder: '建造物を探す' %>
+        <div data-controller="autocomplete" data-autocomplete-url-value="/spots/auto_search" role="combobox" class="flex-grow w-full relative"> <%# class="w-full"を入れないとレイアウト崩れる %>
+          <%= f.search_field :name_or_address_cont, data: { autocomplete_target: 'input' }, class: 'input input-bordered text-xs w-full', placeholder: '建造物を探す' %>
+          <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
+          <ul class="autocomplete-results absolute border border-gray-300 rounded-t-lg rounded-b-lg w-full max-h-60 overflow-auto z-50" data-autocomplete-target="results"></ul>
+        </div>
         <%= f.submit '検索', class: 'btn join-item' %>
       </div>
     </div>

--- a/app/views/spots/_search_form.html.erb
+++ b/app/views/spots/_search_form.html.erb
@@ -2,7 +2,7 @@
   <div class="w-5/6 mx-auto max-w-sm md:max-w-4xl m-3">
     <div class="flex justify-center">
       <div class="join w-full">
-        <div data-controller="autocomplete" data-autocomplete-url-value="/spots/auto_search" role="combobox" class="flex-grow w-full relative"> <%# class="w-full"を入れないとレイアウト崩れる %>
+        <div data-controller="autocomplete" data-autocomplete-url-value="/spots/auto_search" role="combobox" class="flex-grow w-full relative">
           <%= f.search_field :name_or_address_cont, data: { autocomplete_target: 'input' }, class: 'input input-bordered text-xs w-full', placeholder: '建造物を探す' %>
           <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
           <ul class="autocomplete-results absolute border border-gray-300 rounded-t-lg rounded-b-lg w-full max-h-60 overflow-auto z-50" data-autocomplete-target="results"></ul>

--- a/app/views/spots/auto_search.html.erb
+++ b/app/views/spots/auto_search.html.erb
@@ -1,0 +1,5 @@
+<% @spots.each do |spot| %>
+  <li class="py-2 px-4 text-sm text-gray-800 bg-gray-100 hover:bg-gray-200 focus:bg-gray-200" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.name %>">
+    <%= spot.name %>
+  </li>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,46 +2,35 @@ Rails.application.routes.draw do
   get "oauths/oauth"
   get "oauths/callback"
 
-  #トップページのルーティング
   root "static_pages#top"
 
-  #ユーザー登録のルーティング
   resources :users, only: %i[new create]
 
-  # プロフィール関連のルート
   resources :profiles, only: [:index]
 
-  # OAuth認証のコールバックを処理するルーティング（認証プロバイダからのリダイレクトを受け取る）
   post "oauth/callback" => "oauths#callback"
   get "oauth/callback" => "oauths#callback" 
 
-  # 指定されたプロバイダ（GoogleやFacebookなど）でOAuth認証を開始するルーティング
   get "oauth/:provider" => "oauths#oauth", :as => :auth_at_provider
 
-  #ログイン/ログアウト機能のルーティング
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"
   delete "logout", to: "user_sessions#destroy"
 
-  # 場所検索ページのルーティング
   get 'spots/map'
 
-  # 一覧検索ページのルーティング
   resources :spots, only: %i[index show] do
     resources :reviews, only: %i[new create edit destroy], shallow: true
     collection do
-      # ブックマーク一覧表示用のルーティング
       get :bookmarks
+      get :auto_search
     end
   end
 
-  # ブックマーク機能用のルーティング
   resources :bookmarks, only: %i[create destroy]
 
-  #口コミ検索ページのルーティング
   resources :reviews, only: %i[index]
 
-  #AI診断ページのルーティング
   resources :suggestions, only: %i[index] do
     collection do
       get :result

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "autoprefixer": "^10.4.20",
     "daisyui": "^4.12.22",
     "postcss": "^8.4.49",
+    "stimulus-autocomplete": "^3.1.0",
     "tailwindcss": "^3.4.17"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,6 +834,11 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"


### PR DESCRIPTION
■概要
- Spotの一覧検索において、オートコンプリート機能を実装

■内容
- SpotsController に auto_search アクションを追加し、スポット名の部分一致検索に対応（ILIKE を使用）
- Stimulusの stimulus-autocomplete を導入し、JavaScript 側での候補表示を実装
- 検索フォームの部分テンプレート _search_form.html.erb にオートコンプリート用のフィールドを追加
- オートコンプリート結果表示用の部分テンプレート auto_search.html.erb を追加
- Stimulusコントローラのエントリーポイント application.js に autocomplete を登録